### PR TITLE
解决执行命令挂起以及部分设备断开 USB 服务进程被杀的问题。

### DIFF
--- a/pc/pusher.sh
+++ b/pc/pusher.sh
@@ -9,5 +9,5 @@ adb push $dir/launcher.sh  /data/local/tmp
 adb push $dir/libfairy.so  /data/local/tmp
 
 # 不输出 后台执行
-adb shell /data/local/tmp/launcher.sh
+nohup adb shell "nohup /data/local/tmp/launcher.sh > /dev/null 2>&1" &>/dev/null &
 echo 'finish'


### PR DESCRIPTION
解决执行命令时挂起的问题。另外，对于 oppo R9plus 和 三星 s6 edge plus（6.0.1）, nohup 也可以解决断开 USB 后服务不被杀死的问题。